### PR TITLE
Add simple authentication mechanism to avoid abuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Hello,
 
 I'd like to add a custom escalation integration with these URLs:
 
-https://YOUR-HEROKU-APP-NAME.herokuapp.com/create?id=[report id]&url=[report url]&title=[title]&details=[details]
-https://YOUR-HEROKU-APP-NAME.herokuapp.com/view?id=[id]
+https://YOUR-HEROKU-APP-NAME.herokuapp.com/create?id=[report id]&url=[report url]&title=[title]&details=[details]&secret=[app-secret-key]
+https://YOUR-HEROKU-APP-NAME.herokuapp.com/view?id=[id]&secret=[app-secret-key]
 
 Thank you!
 ```
@@ -48,9 +48,10 @@ cat >profiles.clj
 ```
 {:dev {:env {:dev                       "true"
              :pivotaltracker-api-key    "aaaaaaa"
-             :pivotaltracker-project-id "11111111"}}}
+             :pivotaltracker-project-id "11111111"
+             :app-secret-key            "secret"}}}
 ```
 
 ## Run locally
 
-`lein run`, then open `http://localhost:8080/create?id=183837&url=https%3A%2F%2Fhackerone.com%2Freports%2F1111&title=Race+condition&details=foobar`
+`lein run`, then open `http://localhost:8080/create?id=183837&url=https%3A%2F%2Fhackerone.com%2Freports%2F1111&title=Race+condition&details=foobar&secret=[app-secrey-key-from-profiles.clj]`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://YOUR-HEROKU-APP-NAME.herokuapp.com/view?id=[id]
 Thank you!
 ```
 
-Wait for hackerone to confirm that the integration was added.
+Wait for HackerOne to confirm that the integration was added.
 
 ## Step 3
 

--- a/app.json
+++ b/app.json
@@ -9,6 +9,10 @@
     "PIVOTALTRACKER_PROJECT_ID": {
       "description": "Pivotal Tracker Project ID from https://www.pivotaltracker.com/n/projects/PROJECT_ID",
       "required": true
+    },
+    "APP_SECRET_KEY": {
+      "description": "A random secret only known to you and HackerOne to avoid creation of unwanted tickets in Pivotal Tracker",
+      "required": true
     }
   }
 }

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
                  [prone "1.1.4"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [midje "1.8.3"]]
+                 [midje "1.8.3"]
+                 [crypto-equality "1.0.0"]]
   :min-lein-version "2.6.1"
   :plugins [[lein-environ "1.1.0"]
             [lein-midje "3.2.1"]]

--- a/src/hackerone_pivotaltracker/core.clj
+++ b/src/hackerone_pivotaltracker/core.clj
@@ -21,7 +21,7 @@
 
 (defn app-secret-key []
   (or (env :app-secret-key)
-      (throw (RuntimeException. "Application Secret key is not set"))))
+      (throw (RuntimeException. "Application secret key is not set"))))
 
 (defn tracker-project-id []
   (Integer/parseInt (env :pivotaltracker-project-id)))

--- a/src/hackerone_pivotaltracker/core.clj
+++ b/src/hackerone_pivotaltracker/core.clj
@@ -11,7 +11,8 @@
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [ring.middleware.reload :refer [wrap-reload]]
             [environ.core :refer [env]]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [crypto.equality :as crypto]))
 
 (defn tracker-api-key []
   (or (env :pivotaltracker-api-key)


### PR DESCRIPTION
This PR adds a straightforward and simple authentication middleware. The app now requires the user to set an application secret key. This key has to be provided in every request to let it succeed. In case the key isn't provided or incorrect, the app will respond with a 403. The middleware approach was taken simply because every request requires a form of authentication and not to clutter the routes. The specs added for the behaviour are implemented as integration specs, since they don't spec the middleware itself, but rather the request itself that invokes the middleware. The crypto dependency was added for a secure compare to avoid timing attacks.

This is the first time I ever wrote something in Clojure. A double check the code and overall approach is appreciated!

Fixes #1.